### PR TITLE
make value() method parent-compatible

### DIFF
--- a/Model/Datasource/Sybase.php
+++ b/Model/Datasource/Sybase.php
@@ -580,10 +580,11 @@ class Sybase extends DboSource {
      *
      * @param string $data String to be prepared for use in an SQL statement
      * @param string $column The column into which this data will be inserted
+     * @param bool $null Column allows NULL values
      *
      * @return string Quoted and escaped data
      */
-	public function value($data, $column = null) {
+	public function value($data, $column = null, $null = true) {
 		if ($data === null || is_array($data) || is_object($data)) {
 			return parent::value($data, $column);
 		}
@@ -600,7 +601,7 @@ class Sybase extends DboSource {
 			case 'text':
 				return 'N' . $this->_connection->quote($data, PDO::PARAM_STR);
 			default:
-				return parent::value($data, $column);
+				return parent::value($data, $column, $null);
 		}
 	}
 


### PR DESCRIPTION
This makes the `value()` method call compatible with 2.9.x, which added a third parameter to `DboSouce::value()`.